### PR TITLE
Linux' time program integration into the OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\
+	$U/_time\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ UPROGS=\
 	$U/_ln\
 	$U/_ls\
 	$U/_mkdir\
+	$U/_pause\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -97,6 +97,7 @@ void            sched(void);
 void            sleep(void*, struct spinlock*);
 void            userinit(void);
 int             kwait(uint64);
+int				kwait2(uint64, uint64, uint64);
 void            wakeup(void*);
 void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -103,7 +103,6 @@ void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
-struct proc*	lookup_pid(int target_pid);
 
 // swtch.S
 void            swtch(struct context*, struct context*);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -136,6 +136,7 @@ void            argaddr(int, uint64 *);
 int             fetchstr(uint64, char*, int);
 int             fetchaddr(uint64, uint64*);
 void            syscall();
+uint64				sys_ctime();
 
 // trap.c
 extern uint     ticks;

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -102,6 +102,7 @@ void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
+struct proc*	lookup_pid(int target_pid);
 
 // swtch.S
 void            swtch(struct context*, struct context*);

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -57,3 +57,6 @@
 //   TRAPFRAME (p->trapframe, used by the trampoline)
 //   TRAMPOLINE (the same page as in the kernel)
 #define TRAPFRAME (TRAMPOLINE - PGSIZE)
+
+// Project 01 - Goldfish RTC
+#define RTC 0x101000

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -470,9 +470,9 @@ scheduler(void)
         }
         swtch(&c->context, &p->context);
 		if (p -> timing && before != 0) {
-	      after = sys_ctime();
+		  after = sys_ctime();
 	    }
-	    if (after - before) {
+	    if ((after - before) && (after > before)) {
 	  	  p -> user_time += (after - before);
 	    }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -469,10 +469,10 @@ scheduler(void)
           before = sys_ctime();
         }
         swtch(&c->context, &p->context);
-		if (p -> timing) {
+		if (p -> timing && before != 0) {
 	      after = sys_ctime();
 	    }
-	    if ((after - before) > 0) {
+	    if (after - before) {
 	  	  p -> user_time += (after - before);
 	    }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -456,7 +456,7 @@ scheduler(void)
 		if (p -> timing) {
 	      after = sys_ctime();
 	    }
-	    if (((after - before) > 0) && ((after - before) < 50000)) {
+	    if ((after - before) > 0) {
 	  	  p -> user_time += (after - before);
 	    }
 
@@ -701,4 +701,20 @@ procdump(void)
     printf("%d %s %s", p->pid, state, p->name);
     printf("\n");
   }
+}
+
+struct proc *
+lookup_pid(int target_pid) {
+
+	printf("IM TRYING TO FIND: %d\n", target_pid);
+	for (int i = 0; i < NPROC; i++) {
+		printf("proc[%d].pid IS: %d\n", i, proc[i].pid);
+		if (proc[i].pid == target_pid) {
+			return(proc + i);
+		}
+	}
+	// Didn't find the proc
+	printf("Didnt find the proc heh\n");
+	return(0);
+	
 }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -169,6 +169,8 @@ freeproc(struct proc *p)
   p->killed = 0;
   p->xstate = 0;
   p->state = UNUSED;
+  p->timing = 0;
+  p->kern_time = 0;
 }
 
 // Create a user page table for a given process, with no user memory,

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -106,4 +106,5 @@ struct proc {
   char name[16];               // Process name (debugging)
   short timing;				   // Toggles timing
   uint64 kern_time;            // Kernel Time Tracking
+  uint64 user_time;			   // User Time Tracking
 };

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -104,4 +104,6 @@ struct proc {
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
+  short timing;				   // Toggles timing
+  uint64 kern_time;            // Kernel Time Tracking
 };

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -107,4 +107,5 @@ struct proc {
   short timing;				   // Toggles timing
   uint64 kern_time;            // Kernel Time Tracking
   uint64 user_time;			   // User Time Tracking
+  uint64 real_time;			   // Real Time Tracking
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_ctime(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_ctime]   sys_ctime,
 };
 
 void

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -158,7 +158,7 @@ syscall(void)
 	
 	if (p->timing && before != 0) {
 	  after = sys_ctime();
-	  if ((after - before) > 0) {
+	  if (((after - before) > 0) && (after > before)) {
 	  	// printf("AFTER-BEFORE: %ld\n", (after-before));
 	  	p->kern_time += (after - before);
 	  }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -156,7 +156,8 @@ syscall(void)
 	
 	if (p->timing) {
 	  after = sys_ctime();
-	  if ((after - before) < 50000 && (after - before) > 0) {
+	  if ((after - before) > 0) {
+	  	// printf("AFTER-BEFORE: %ld\n", (after-before));
 	  	p->kern_time += (after - before);
 	  }
 	}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -104,6 +104,7 @@ extern uint64 sys_close(void);
 extern uint64 sys_ctime(void);
 extern uint64 sys_timtog(void);
 extern uint64 sys_getkt(void);
+extern uint64 sys_getut(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -132,6 +133,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_ctime]   sys_ctime,
 [SYS_timtog]  sys_timtog,
 [SYS_getkt]   sys_getkt,
+[SYS_getut]   sys_getut,
 };
 
 void
@@ -145,13 +147,18 @@ syscall(void)
     // Use num to lookup the system call function for num, call it,
     // and store its return value in p->trapframe->a0
     uint64 before = 0;
+    uint64 after = 0;
     if (p->timing) {
-      sys_ctime();
       before = sys_ctime();
     }
+    
 	uint64 holder = syscalls[num]();
+	
 	if (p->timing) {
-	  p->kern_time += sys_ctime() - before;
+	  after = sys_ctime();
+	  if ((after - before) <= 500000) {
+	    p->kern_time += (after - before);
+	  }	
 	}
     p->trapframe->a0 = holder;
   } else {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -156,7 +156,7 @@ syscall(void)
     
 	uint64 holder = syscalls[num]();
 	
-	if (p->timing) {
+	if (p->timing && before != 0) {
 	  after = sys_ctime();
 	  if ((after - before) > 0) {
 	  	// printf("AFTER-BEFORE: %ld\n", (after-before));

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -103,8 +103,6 @@ extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
 extern uint64 sys_ctime(void);
 extern uint64 sys_timtog(void);
-extern uint64 sys_getkt(void);
-extern uint64 sys_getut(void);
 extern uint64 sys_wait2(void);
 
 // An array mapping syscall numbers from syscall.h
@@ -133,8 +131,6 @@ static uint64 (*syscalls[])(void) = {
 [SYS_close]   sys_close,
 [SYS_ctime]   sys_ctime,
 [SYS_timtog]  sys_timtog,
-[SYS_getkt]   sys_getkt,
-[SYS_getut]   sys_getut,
 [SYS_wait2]   sys_wait2,
 };
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -105,6 +105,7 @@ extern uint64 sys_ctime(void);
 extern uint64 sys_timtog(void);
 extern uint64 sys_getkt(void);
 extern uint64 sys_getut(void);
+extern uint64 sys_wait2(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -134,6 +135,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_timtog]  sys_timtog,
 [SYS_getkt]   sys_getkt,
 [SYS_getut]   sys_getut,
+[SYS_wait2]   sys_wait2,
 };
 
 void

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -156,10 +156,9 @@ syscall(void)
     
 	uint64 holder = syscalls[num]();
 	
-	if (p->timing && before != 0) {
+	if (p->timing && before > 0) {
 	  after = sys_ctime();
 	  if (((after - before) > 0) && (after > before)) {
-	  	// printf("AFTER-BEFORE: %ld\n", (after-before));
 	  	p->kern_time += (after - before);
 	  }
 	}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -156,9 +156,9 @@ syscall(void)
 	
 	if (p->timing) {
 	  after = sys_ctime();
-	  if ((after - before) <= 500000) {
-	    p->kern_time += (after - before);
-	  }	
+	  if ((after - before) < 50000 && (after - before) > 0) {
+	  	p->kern_time += (after - before);
+	  }
 	}
     p->trapframe->a0 = holder;
   } else {

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_ctime  22

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -21,3 +21,5 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_ctime  22
+#define SYS_timtog 23
+#define SYS_getkt  24

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -22,6 +22,4 @@
 #define SYS_close  21
 #define SYS_ctime  22
 #define SYS_timtog 23
-#define SYS_getkt  24
-#define SYS_getut  25
-#define SYS_wait2  26
+#define SYS_wait2  24

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -23,3 +23,4 @@
 #define SYS_ctime  22
 #define SYS_timtog 23
 #define SYS_getkt  24
+#define SYS_getut  25

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -24,3 +24,4 @@
 #define SYS_timtog 23
 #define SYS_getkt  24
 #define SYS_getut  25
+#define SYS_wait2  26

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -37,6 +37,17 @@ sys_wait(void)
 }
 
 uint64
+sys_wait2(void)
+{
+	uint64 p, usr, kern;
+	argaddr(0, &p);
+	argaddr(1, &usr);
+	argaddr(2, &kern);
+
+	return kwait2(p, usr, kern);
+}
+
+uint64
 sys_sbrk(void)
 {
   uint64 addr;

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -145,23 +145,25 @@ sys_timtog()
 uint64
 sys_getkt(int target_pid)
 {
-	argint(0, &target_pid);
-	struct proc *p = lookup_pid(target_pid);
-	if (p) {
-		return p -> kern_time;	
-	} else {
-		return(0);
-	}
+	// argint(0, &target_pid);
+	// struct proc *p = lookup_pid(target_pid);
+	// if (p) {
+	// 	return p -> kern_time;	
+	// } else {
+	// 	return(0);
+	// }
+	return 0;
 }
 
 uint64
 sys_getut(int target_pid)
 {
-	argint(0, &target_pid);
-	struct proc *p = lookup_pid(target_pid);
-	if (p) {
-		return p -> user_time;
-	} else {
-		return(0);
-	}
+	// argint(0, &target_pid);
+	// struct proc *p = lookup_pid(target_pid);
+	// if (p) {
+	// 	return p -> user_time;
+	// } else {
+	// 	return(0);
+	// }
+	return 0;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -105,3 +105,11 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+uint64
+sys_ctime(void)
+{
+	uint32 first = *((uint32 *) RTC);
+	uint32 second = *((uint32 *) (RTC + 0x4));
+	return (((uint64) second << 32 | first) % 1000000000);
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -123,7 +123,11 @@ sys_ctime(void)
   uint32 second = *((uint32 *) (RTC + 0x4));
   uint32 first = *((uint32 *) (RTC));
   // printf("%ld\n", ((uint64) second << 32 | first) / 1000000);
-  return (((uint64) second << 32 | first) / 1000000);
+  if (myproc() -> timing) {
+  	return (((uint64) second << 32 | first) / 1000000);
+  } else {
+  	return ((uint64) second << 32 | first);
+  }
 }
 
 uint64

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -119,7 +119,7 @@ sys_timtog()
 {
   struct proc *p = myproc();
   p->timing = !p->timing;
-  if (p->timing) {
+  if (p -> timing) {
     return 1;
   } else {
     return 0;
@@ -130,5 +130,12 @@ uint64
 sys_getkt()
 {
 	struct proc *p = myproc();
-	return p->kern_time;
+	return p -> kern_time;
+}
+
+uint64
+sys_getut()
+{
+	struct proc *p = myproc();
+	return p -> user_time;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -141,29 +141,3 @@ sys_timtog()
     return 0;
   }
 }
-
-uint64
-sys_getkt(int target_pid)
-{
-	// argint(0, &target_pid);
-	// struct proc *p = lookup_pid(target_pid);
-	// if (p) {
-	// 	return p -> kern_time;	
-	// } else {
-	// 	return(0);
-	// }
-	return 0;
-}
-
-uint64
-sys_getut(int target_pid)
-{
-	// argint(0, &target_pid);
-	// struct proc *p = lookup_pid(target_pid);
-	// if (p) {
-	// 	return p -> user_time;
-	// } else {
-	// 	return(0);
-	// }
-	return 0;
-}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -120,8 +120,8 @@ sys_uptime(void)
 uint64
 sys_ctime(void)
 {
-  uint32 first = *((uint32 *) RTC);
-  uint32 second = *((uint32 *) (RTC + 0x4));
+  volatile uint32 first = *((uint32 *) RTC);
+  volatile uint32 second = *((uint32 *) (RTC + 0x4));
   return ((uint64) second << 32 | first);
 }
 

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -109,7 +109,7 @@ sys_uptime(void)
 uint64
 sys_ctime(void)
 {
-	uint32 first = *((uint32 *) RTC);
-	uint32 second = *((uint32 *) (RTC + 0x4));
-	return (((uint64) second << 32 | first) % 1000000000);
+  uint32 first = *((uint32 *) RTC);
+  uint32 second = *((uint32 *) (RTC + 0x4));
+  return ((uint64) second << 32 | first) / 1000000;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -113,3 +113,22 @@ sys_ctime(void)
   uint32 second = *((uint32 *) (RTC + 0x4));
   return ((uint64) second << 32 | first) / 1000000;
 }
+
+uint64
+sys_timtog()
+{
+  struct proc *p = myproc();
+  p->timing = !p->timing;
+  if (p->timing) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+uint64
+sys_getkt()
+{
+	struct proc *p = myproc();
+	return p->kern_time;
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -111,7 +111,7 @@ sys_ctime(void)
 {
   uint32 first = *((uint32 *) RTC);
   uint32 second = *((uint32 *) (RTC + 0x4));
-  return ((uint64) second << 32 | first) / 1000000;
+  return ((uint64) second << 32 | first);
 }
 
 uint64
@@ -127,15 +127,25 @@ sys_timtog()
 }
 
 uint64
-sys_getkt()
+sys_getkt(int target_pid)
 {
-	struct proc *p = myproc();
-	return p -> kern_time;
+	argint(0, &target_pid);
+	struct proc *p = lookup_pid(target_pid);
+	if (p) {
+		return p -> kern_time;	
+	} else {
+		return(0);
+	}
 }
 
 uint64
-sys_getut()
+sys_getut(int target_pid)
 {
-	struct proc *p = myproc();
-	return p -> user_time;
+	argint(0, &target_pid);
+	struct proc *p = lookup_pid(target_pid);
+	if (p) {
+		return p -> user_time;
+	} else {
+		return(0);
+	}
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -120,9 +120,10 @@ sys_uptime(void)
 uint64
 sys_ctime(void)
 {
-  volatile uint32 first = *((uint32 *) RTC);
-  volatile uint32 second = *((uint32 *) (RTC + 0x4));
-  return ((uint64) second << 32 | first);
+  uint32 second = *((uint32 *) (RTC + 0x4));
+  uint32 first = *((uint32 *) (RTC));
+  // printf("%ld\n", ((uint64) second << 32 | first) / 1000000);
+  return (((uint64) second << 32 | first) / 1000000);
 }
 
 uint64

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -47,7 +47,7 @@ usertrap(void)
   w_stvec((uint64)kernelvec);
 
   struct proc *p = myproc();
-  
+
   // save user program counter.
   p->trapframe->epc = r_sepc();
   

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -47,6 +47,9 @@ kvmmake(void)
 
   // allocate and map a kernel stack for each process.
   proc_mapstacks(kpgtbl);
+
+  // Project 01 - to get the current time
+  kvmmap(kpgtbl, RTC, RTC, PGSIZE, PTE_R | PTE_W);
   
   return kpgtbl;
 }

--- a/user/pause.c
+++ b/user/pause.c
@@ -5,8 +5,8 @@ int main() {
 
 	printf("Looping...\n");
 	uint64 a = 0;
-	for (int i = 0; i < 1500000000; i++) {
-		printf("ctime: %ld\n", ctime());
+	for (int i = 0; i < 1550000000; i++) {
+		// printf("ctime: %ld\n", ctime());
 		a++;
 	}
 	printf("Done!\n");

--- a/user/pause.c
+++ b/user/pause.c
@@ -6,6 +6,7 @@ int main() {
 	printf("Looping...\n");
 	uint64 a = 0;
 	for (int i = 0; i < 1500000000; i++) {
+		printf("ctime: %ld\n", ctime());
 		a++;
 	}
 	printf("Done!\n");

--- a/user/pause.c
+++ b/user/pause.c
@@ -1,0 +1,14 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int main() {
+
+	printf("Looping...\n");
+	uint64 a = 0;
+	for (int i = 0; i < 1500000000; i++) {
+		a++;
+	}
+	printf("Done!\n");
+	return 1;
+	
+}

--- a/user/time.c
+++ b/user/time.c
@@ -1,6 +1,13 @@
 #include "kernel/types.h"
 #include "user/user.h"
 
+void printtime(char *category, int raw_ms, int POSIX) {
+
+	if (raw_ms <=0) {
+		printf("%s\t%d", category, raw_ms);
+	
+}
+
 int main(int argc, char *argv[]) {
 
 	// A buffer
@@ -10,14 +17,19 @@ int main(int argc, char *argv[]) {
 	short POSIX = 0;
 	short arg_start_idx = 1;
 	if (argc == 1) {
-		printf("0 seconds bih\n");
+		timtog();
+		printf("real	0m0.000s\n");
+		printf("user	0m0.000s\n");
+		printf("sys 	0m0.000s\n");
 		return 1;
 	} else if (argc >= 2){
 		char *flag = "-p";
 		if (strcmp(flag, argv[1]) == 0) {
 			POSIX = 1;
 			if (argc == 2) {
-				printf("Still 0 bih\n");
+				printf("real	0.00s\n");
+				printf("user	0.00s\n");
+				printf("sys 	0.00s\n");
 				return 1;
 			} else {
 				arg_start_idx++;
@@ -29,6 +41,7 @@ int main(int argc, char *argv[]) {
 
 	int pid = fork();
 	int ret = 0;
+	timtog();
 	if (pid == 0) {
 		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
 	} else {
@@ -54,5 +67,6 @@ int main(int argc, char *argv[]) {
 		}
 		ret = 1;
 	}
+	printf("%d\n", (getkt() % 1000000));
 	return ret;
 }

--- a/user/time.c
+++ b/user/time.c
@@ -1,27 +1,27 @@
 #include "kernel/types.h"
 #include "user/user.h"
 
-void printtime(char *category, int raw_ns, int POSIX) {
+void printtime(char *category, int raw, int POSIX) {
 
-	if (raw_ns <=0) {
+	if (raw <=0) {
 		if (POSIX) {
 			printf("%s\t0.00s\n", category);
 		} else {
 			printf("%s\t0m0.000s\n", category);
 		}
 	} else {
-		uint64 seconds = ((raw_ns % 60000000000) / 1000000000);
+		uint64 seconds = ((raw % 100000000) / 1000) % 60;
 		// printf("SECONDS: %ld\n", seconds);
 		if (POSIX) {
-			uint64 p_ms = ((((raw_ns) % 60000000000) % 1000000000) / 10000000);
+			uint64 p_ms = (raw % 1000) / 10;
 			if (p_ms < 10) {
 				printf("%s\t%lu.0%lus\n", category, seconds, p_ms);
 			} else {
 				printf("%s\t%lu.%lus\n", category, seconds, p_ms);
 			}
 		} else {
-			uint64 minutes = raw_ns / 60000000000;
-			uint64 ms = ((raw_ns % 60000000000) % 1000000000) / 1000000;
+			uint64 minutes = ((raw % 100000000) / 1000) / 60;
+			uint64 ms = (raw % 1000);
 			if (ms < 100) {
 				if (ms > 9) {
 					printf("%s\t%lum%lu.0%lus\n", category, minutes, seconds, ms);
@@ -43,14 +43,10 @@ int main(int argc, char *argv[]) {
 	ctime();
 	ctime();
 
-	// printf("%ld\n", ctime());
-	// printf("%ld\n", ctime());
-	// printf("%ld\n", ctime());
-
 	short POSIX = 0;
 	short arg_start_idx = 1;
 	if (argc == 1) {
-		printtime("real", 0, 0);
+		printtime("\nreal", 0, 0);
 		printtime("user", 0, 0);
 		printtime("sys", 0, 0);
 		return 1;
@@ -59,7 +55,7 @@ int main(int argc, char *argv[]) {
 		if (strcmp(flag, argv[1]) == 0) {
 			POSIX = 1;
 			if (argc == 2) {
-				printtime("real", 0, 1);
+				printtime("\nreal", 0, 1);
 				printtime("user", 0, 1);
 				printtime("sys", 0, 1);
 				return 1;
@@ -70,29 +66,23 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	timtog();
 	uint64 time_before = ctime();
 	int pid = fork();
 	int ret = 0;
 	if (pid == 0) {
 		timtog();
-		time_before = ctime();
 		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
 	} else {
 		uint64 utime, kerntime;
 		wait2(0, &utime, &kerntime);
 		uint64 time_after = ctime();
-		// printf("before: %ld\n", time_before);
-		// printf("after: %ld\n", time_after);
-		// printf("kern: %ld\n", kerntime);
-		// printf("user: %ld\n", utime);
 		uint64 final_time = (time_after - time_before);
-		printf("\nrt: %lu\n", final_time);
-		printtime("real", final_time, POSIX);
-		printf("ut: %lu\n", utime);
+		printtime("\nreal", final_time, POSIX);
 		printtime("user", utime, POSIX);
-		printf("kt: %lu\n", kerntime);
 		printtime("sys", kerntime, POSIX);
+		// printf("%ld\n", final_time);
+		// printf("%ld\n", utime);
+		// printf("%ld\n", kerntime);
 		ret = 1;
 	}
 	return ret;

--- a/user/time.c
+++ b/user/time.c
@@ -10,26 +10,26 @@ void printtime(char *category, int raw, int POSIX) {
 			printf("%s\t0m0.000s\n", category);
 		}
 	} else {
-		uint64 seconds = ((raw % 1000000000) / 1000) % 60;
+		uint8 seconds = ((raw % 1000000000) / 1000) % 60;
 		// printf("SECONDS: %ld\n", seconds);
 		if (POSIX) {
-			uint64 p_ms = (raw % 1000) / 10;
+			uint8 p_ms = (raw % 1000) / 10;
 			if (p_ms < 10) {
-				printf("%s\t%lu.0%lus\n", category, seconds, p_ms);
+				printf("%s\t%d.0%ds\n", category, seconds, p_ms);
 			} else {
-				printf("%s\t%lu.%lus\n", category, seconds, p_ms);
+				printf("%s\t%d.%ds\n", category, seconds, p_ms);
 			}
 		} else {
 			uint64 minutes = ((raw % 1000000000) / 1000) / 60;
-			uint64 ms = (raw % 1000);
+			uint16 ms = (raw % 1000);
 			if (ms < 100) {
 				if (ms > 9) {
-					printf("%s\t%lum%lu.0%lus\n", category, minutes, seconds, ms);
+					printf("%s\t%lum%d.0%ds\n", category, minutes, seconds, ms);
 				} else {
-					printf("%s\t%lum%lu.00%lus\n", category, minutes, seconds, ms);	
+					printf("%s\t%lum%d.00%ds\n", category, minutes, seconds, ms);	
 				}
 			} else {
-				printf("%s\t%lum%lu.%lus\n", category, minutes, seconds, ms);
+				printf("%s\t%lum%d.%ds\n", category, minutes, seconds, ms);
 			}
 		}
 	}
@@ -66,6 +66,7 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	timtog();
 	uint64 time_before = ctime();
 	int pid = fork();
 	int ret = 0;

--- a/user/time.c
+++ b/user/time.c
@@ -67,7 +67,9 @@ int main(int argc, char *argv[]) {
 		uint64 time_after = ctime();
 		uint64 final_time = (time_after - time_before) % 1000000;
 		printtime("\nreal", final_time, POSIX);
+		printf("ut: %ld\n", getut());
 		printtime("user", getut(), POSIX);
+		printf("kt: %ld\n", getkt());
 		printtime("sys", getkt(), POSIX);
 		ret = 1;
 	}

--- a/user/time.c
+++ b/user/time.c
@@ -70,7 +70,8 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-	uint64 time_before = 0;
+	timtog();
+	uint64 time_before = ctime();
 	int pid = fork();
 	int ret = 0;
 	if (pid == 0) {
@@ -81,7 +82,10 @@ int main(int argc, char *argv[]) {
 		uint64 utime, kerntime;
 		wait2(0, &utime, &kerntime);
 		uint64 time_after = ctime();
+		// printf("before: %ld\n", time_before);
 		// printf("after: %ld\n", time_after);
+		// printf("kern: %ld\n", kerntime);
+		// printf("user: %ld\n", utime);
 		uint64 final_time = (time_after - time_before);
 		printf("\nrt: %lu\n", final_time);
 		printtime("real", final_time, POSIX);

--- a/user/time.c
+++ b/user/time.c
@@ -10,7 +10,7 @@ void printtime(char *category, int raw, int POSIX) {
 			printf("%s\t0m0.000s\n", category);
 		}
 	} else {
-		uint64 seconds = ((raw % 100000000) / 1000) % 60;
+		uint64 seconds = ((raw % 1000000000) / 1000) % 60;
 		// printf("SECONDS: %ld\n", seconds);
 		if (POSIX) {
 			uint64 p_ms = (raw % 1000) / 10;
@@ -20,7 +20,7 @@ void printtime(char *category, int raw, int POSIX) {
 				printf("%s\t%lu.%lus\n", category, seconds, p_ms);
 			}
 		} else {
-			uint64 minutes = ((raw % 100000000) / 1000) / 60;
+			uint64 minutes = ((raw % 1000000000) / 1000) / 60;
 			uint64 ms = (raw % 1000);
 			if (ms < 100) {
 				if (ms > 9) {

--- a/user/time.c
+++ b/user/time.c
@@ -4,7 +4,26 @@
 void printtime(char *category, int raw_ms, int POSIX) {
 
 	if (raw_ms <=0) {
-		printf("%s\t%d", category, raw_ms);
+		if (POSIX) {
+			printf("%s\t0.00s\n", category);
+		} else {
+			printf("%s\t0m0.000s\n", category);
+		}
+	} else {
+		uint64 seconds = (raw_ms % 60000) / 1000;
+		if (POSIX) {
+			uint64 p_ms = (((raw_ms) % 1000) / 10);
+			printf("%s\t%ld.%lds\n", category, seconds, p_ms);
+		} else {
+			uint64 minutes = raw_ms / 60000;
+			uint64 ms = (raw_ms) % 1000;
+			if (ms < 100) {
+				printf("%s\t%ldm%ld.0%lds\n", category, minutes, seconds, ms);
+			} else {
+				printf("%s\t%ldm%ld.%lds\n", category, minutes, seconds, ms);
+			}
+		}
+	}
 	
 }
 
@@ -18,22 +37,21 @@ int main(int argc, char *argv[]) {
 	short arg_start_idx = 1;
 	if (argc == 1) {
 		timtog();
-		printf("real	0m0.000s\n");
-		printf("user	0m0.000s\n");
-		printf("sys 	0m0.000s\n");
+		printtime("real", 0, 0);
+		printtime("user", 0, 0);
+		printtime("sys", 0, 0);
 		return 1;
 	} else if (argc >= 2){
 		char *flag = "-p";
 		if (strcmp(flag, argv[1]) == 0) {
 			POSIX = 1;
 			if (argc == 2) {
-				printf("real	0.00s\n");
-				printf("user	0.00s\n");
-				printf("sys 	0.00s\n");
+				printtime("real", 0, 1);
+				printtime("user", 0, 1);
+				printtime("sys", 0, 1);
 				return 1;
 			} else {
 				arg_start_idx++;
-				printf("Ay you doing sumn DIF\n");
 			}
 			
 		}
@@ -48,25 +66,10 @@ int main(int argc, char *argv[]) {
 		wait(0);
 		uint64 time_after = ctime();
 		uint64 final_time = (time_after - time_before) % 1000000;
-		// printf("%ld\n", time_before);
-		// printf("%ld\n", time_after);
-		uint64 seconds = (final_time % 60000) / 1000;
-		if (POSIX == 1) {
-			//printf("Aight u POSIX-ing\n");
-			uint64 p_ms = (((final_time) % 1000) / 10);
-			printf("real	%ld.%lds\n", seconds, p_ms);
-			printf("user	%ld.%lds\n", seconds, p_ms);
-			printf("sys 	%ld.%lds\n", seconds, p_ms);
-		} else {
-			// printf("NO POSIX\n");
-			uint64 minutes = final_time / 60000;
-			uint64 ms = (final_time) % 1000;
-			printf("real	%ldm%ld.%lds\n", minutes, seconds, ms);
-			printf("user	%ldm%ld.%lds\n", minutes, seconds, ms);
-			printf("sys 	%ldm%ld.%lds\n", minutes, seconds, ms);
-		}
+		printtime("\nreal", final_time, POSIX);
+		printtime("user", getut(), POSIX);
+		printtime("sys", getkt(), POSIX);
 		ret = 1;
 	}
-	printf("%d\n", (getkt() % 1000000));
 	return ret;
 }

--- a/user/time.c
+++ b/user/time.c
@@ -44,7 +44,6 @@ int main(int argc, char *argv[]) {
 	short POSIX = 0;
 	short arg_start_idx = 1;
 	if (argc == 1) {
-		timtog();
 		printtime("real", 0, 0);
 		printtime("user", 0, 0);
 		printtime("sys", 0, 0);
@@ -67,19 +66,20 @@ int main(int argc, char *argv[]) {
 
 	int pid = fork();
 	int ret = 0;
-	timtog();
 	if (pid == 0) {
+		timtog();
 		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
 	} else {
-		wait(0);
+		uint64 utime, kerntime;
+		wait2(0, &utime, &kerntime);
 		uint64 time_after = ctime();
 		uint64 final_time = (time_after - time_before);
-		// printf("\nrt: %ld\n", final_time);
+		printf("\nrt: %ld\n", final_time);
 		printtime("real", final_time, POSIX);
-		// printf("ut: %ld\n", getut(pid));
-		printtime("user", getut(pid), POSIX);
-		// printf("kt: %ld\n", getkt(pid));
-		printtime("sys", getkt(pid), POSIX);
+		printf("ut: %ld\n", utime);
+		printtime("user", utime, POSIX);
+		printf("kt: %ld\n", kerntime);
+		printtime("sys", kerntime, POSIX);
 		ret = 1;
 	}
 	return ret;

--- a/user/time.c
+++ b/user/time.c
@@ -1,0 +1,54 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+int main(int argc, char *argv[]) {
+
+	// A buffer
+	uint64 time_before = ctime();
+
+	time_before = ctime();
+	short POSIX = 0;
+	short arg_start_idx = 1;
+	if (argc == 1) {
+		printf("0 seconds bih\n");
+		return 1;
+	} else if (argc >= 2){
+		char *flag = "-p";
+		if (strcmp(flag, argv[1]) == 0) {
+			POSIX = 1;
+			if (argc == 2) {
+				printf("Still 0 bih\n");
+				return 1;
+			} else {
+				arg_start_idx++;
+				printf("Ay you doing sumn DIF\n");
+			}
+			
+		}
+	}
+
+	int pid = fork();
+	int ret = 0;
+	if (pid == 0) {
+		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
+	} else {
+		wait(0);
+	}
+
+	uint64 time_after = ctime();
+	uint64 final_time = time_after - time_before;
+	printf("%ld\n", time_before);
+	printf("%ld\n", time_before);
+	uint64 minutes = final_time / 60000;
+	uint64 seconds = (final_time % 60000) / 1000;
+	uint64 ms = (final_time) % 1000;
+	if (POSIX == 1) {
+		printf("Aight u POSIX-ing\n");
+		printf("Final Time: %ld\n OR...\n %ld minutes\n %ld seconds\n %ld ms\n", final_time, minutes, seconds, ms);
+	} else {
+		printf("NO POSIX\n");
+		printf("Final Time: %ld\n OR...\n %ld minutes\n %ld seconds\n %ld ms\n", final_time, minutes, seconds, ms);	
+	}
+	
+	return ret;
+}

--- a/user/time.c
+++ b/user/time.c
@@ -1,22 +1,26 @@
 #include "kernel/types.h"
 #include "user/user.h"
 
-void printtime(char *category, int raw_ms, int POSIX) {
+void printtime(char *category, int raw_ns, int POSIX) {
 
-	if (raw_ms <=0) {
+	if (raw_ns <=0) {
 		if (POSIX) {
 			printf("%s\t0.00s\n", category);
 		} else {
 			printf("%s\t0m0.000s\n", category);
 		}
 	} else {
-		uint64 seconds = (raw_ms % 60000) / 1000;
+		uint64 seconds = (raw_ns % 60000000000) / 1000000000;
 		if (POSIX) {
-			uint64 p_ms = (((raw_ms) % 1000) / 10);
-			printf("%s\t%ld.%lds\n", category, seconds, p_ms);
+			uint64 p_ms = (((raw_ns) % 60000000000) / 100000000);
+			if (p_ms < 10) {
+				printf("%s\t%ld.0%lds\n", category, seconds, p_ms);
+			} else {
+				printf("%s\t%ld.%lds\n", category, seconds, p_ms);
+			}
 		} else {
-			uint64 minutes = raw_ms / 60000;
-			uint64 ms = (raw_ms) % 1000;
+			uint64 minutes = raw_ns / 60000000000;
+			uint64 ms = (raw_ns % 60000000000) / 10000000;
 			if (ms < 100) {
 				printf("%s\t%ldm%ld.0%lds\n", category, minutes, seconds, ms);
 			} else {
@@ -31,6 +35,10 @@ int main(int argc, char *argv[]) {
 
 	// A buffer
 	ctime();
+
+	printf("%ld\n", ctime());
+	printf("%ld\n", ctime());
+	printf("%ld\n", ctime());
 
 	uint64 time_before = ctime();
 	short POSIX = 0;
@@ -65,12 +73,13 @@ int main(int argc, char *argv[]) {
 	} else {
 		wait(0);
 		uint64 time_after = ctime();
-		uint64 final_time = (time_after - time_before) % 1000000;
-		printtime("\nreal", final_time, POSIX);
-		printf("ut: %ld\n", getut());
-		printtime("user", getut(), POSIX);
-		printf("kt: %ld\n", getkt());
-		printtime("sys", getkt(), POSIX);
+		uint64 final_time = (time_after - time_before);
+		// printf("\nrt: %ld\n", final_time);
+		printtime("real", final_time, POSIX);
+		// printf("ut: %ld\n", getut(pid));
+		printtime("user", getut(pid), POSIX);
+		// printf("kt: %ld\n", getkt(pid));
+		printtime("sys", getkt(pid), POSIX);
 		ret = 1;
 	}
 	return ret;

--- a/user/time.c
+++ b/user/time.c
@@ -4,9 +4,9 @@
 int main(int argc, char *argv[]) {
 
 	// A buffer
-	uint64 time_before = ctime();
+	ctime();
 
-	time_before = ctime();
+	uint64 time_before = ctime();
 	short POSIX = 0;
 	short arg_start_idx = 1;
 	if (argc == 1) {
@@ -33,22 +33,26 @@ int main(int argc, char *argv[]) {
 		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
 	} else {
 		wait(0);
+		uint64 time_after = ctime();
+		uint64 final_time = (time_after - time_before) % 1000000;
+		// printf("%ld\n", time_before);
+		// printf("%ld\n", time_after);
+		uint64 seconds = (final_time % 60000) / 1000;
+		if (POSIX == 1) {
+			//printf("Aight u POSIX-ing\n");
+			uint64 p_ms = (((final_time) % 1000) / 10);
+			printf("real	%ld.%lds\n", seconds, p_ms);
+			printf("user	%ld.%lds\n", seconds, p_ms);
+			printf("sys 	%ld.%lds\n", seconds, p_ms);
+		} else {
+			// printf("NO POSIX\n");
+			uint64 minutes = final_time / 60000;
+			uint64 ms = (final_time) % 1000;
+			printf("real	%ldm%ld.%lds\n", minutes, seconds, ms);
+			printf("user	%ldm%ld.%lds\n", minutes, seconds, ms);
+			printf("sys 	%ldm%ld.%lds\n", minutes, seconds, ms);
+		}
+		ret = 1;
 	}
-
-	uint64 time_after = ctime();
-	uint64 final_time = time_after - time_before;
-	printf("%ld\n", time_before);
-	printf("%ld\n", time_before);
-	uint64 minutes = final_time / 60000;
-	uint64 seconds = (final_time % 60000) / 1000;
-	uint64 ms = (final_time) % 1000;
-	if (POSIX == 1) {
-		printf("Aight u POSIX-ing\n");
-		printf("Final Time: %ld\n OR...\n %ld minutes\n %ld seconds\n %ld ms\n", final_time, minutes, seconds, ms);
-	} else {
-		printf("NO POSIX\n");
-		printf("Final Time: %ld\n OR...\n %ld minutes\n %ld seconds\n %ld ms\n", final_time, minutes, seconds, ms);	
-	}
-	
 	return ret;
 }

--- a/user/time.c
+++ b/user/time.c
@@ -10,21 +10,26 @@ void printtime(char *category, int raw_ns, int POSIX) {
 			printf("%s\t0m0.000s\n", category);
 		}
 	} else {
-		uint64 seconds = (raw_ns % 60000000000) / 1000000000;
+		uint64 seconds = ((raw_ns % 60000000000) / 1000000000);
+		// printf("SECONDS: %ld\n", seconds);
 		if (POSIX) {
-			uint64 p_ms = (((raw_ns) % 60000000000) / 100000000);
+			uint64 p_ms = ((((raw_ns) % 60000000000) % 1000000000) / 10000000);
 			if (p_ms < 10) {
-				printf("%s\t%ld.0%lds\n", category, seconds, p_ms);
+				printf("%s\t%lu.0%lus\n", category, seconds, p_ms);
 			} else {
-				printf("%s\t%ld.%lds\n", category, seconds, p_ms);
+				printf("%s\t%lu.%lus\n", category, seconds, p_ms);
 			}
 		} else {
 			uint64 minutes = raw_ns / 60000000000;
-			uint64 ms = (raw_ns % 60000000000) / 10000000;
+			uint64 ms = ((raw_ns % 60000000000) % 1000000000) / 1000000;
 			if (ms < 100) {
-				printf("%s\t%ldm%ld.0%lds\n", category, minutes, seconds, ms);
+				if (ms > 9) {
+					printf("%s\t%lum%lu.0%lus\n", category, minutes, seconds, ms);
+				} else {
+					printf("%s\t%lum%lu.00%lus\n", category, minutes, seconds, ms);	
+				}
 			} else {
-				printf("%s\t%ldm%ld.%lds\n", category, minutes, seconds, ms);
+				printf("%s\t%lum%lu.%lus\n", category, minutes, seconds, ms);
 			}
 		}
 	}
@@ -35,12 +40,13 @@ int main(int argc, char *argv[]) {
 
 	// A buffer
 	ctime();
+	ctime();
+	ctime();
 
-	printf("%ld\n", ctime());
-	printf("%ld\n", ctime());
-	printf("%ld\n", ctime());
+	// printf("%ld\n", ctime());
+	// printf("%ld\n", ctime());
+	// printf("%ld\n", ctime());
 
-	uint64 time_before = ctime();
 	short POSIX = 0;
 	short arg_start_idx = 1;
 	if (argc == 1) {
@@ -64,21 +70,24 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	uint64 time_before = 0;
 	int pid = fork();
 	int ret = 0;
 	if (pid == 0) {
 		timtog();
+		time_before = ctime();
 		ret = exec(argv[arg_start_idx], &argv[arg_start_idx]);
 	} else {
 		uint64 utime, kerntime;
 		wait2(0, &utime, &kerntime);
 		uint64 time_after = ctime();
+		// printf("after: %ld\n", time_after);
 		uint64 final_time = (time_after - time_before);
-		printf("\nrt: %ld\n", final_time);
+		printf("\nrt: %lu\n", final_time);
 		printtime("real", final_time, POSIX);
-		printf("ut: %ld\n", utime);
+		printf("ut: %lu\n", utime);
 		printtime("user", utime, POSIX);
-		printf("kt: %ld\n", kerntime);
+		printf("kt: %lu\n", kerntime);
 		printtime("sys", kerntime, POSIX);
 		ret = 1;
 	}

--- a/user/user.h
+++ b/user/user.h
@@ -26,8 +26,8 @@ int pause(int);
 int uptime(void);
 uint64 ctime(void);
 int timtog(void);
-uint64 getkt(void);
-uint64 getut(void);
+uint64 getkt(uint64 target_pid);
+uint64 getut(uint64 target_pid);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -6,6 +6,7 @@ struct stat;
 int fork(void);
 int exit(int) __attribute__((noreturn));
 int wait(int*);
+int wait2(int*, uint64*, uint64*);
 int pipe(int*);
 int write(int, const void*, int);
 int read(int, void*, int);

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,7 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
+int ctime(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -25,6 +25,8 @@ char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
 int ctime(void);
+int timtog(void);
+int getkt(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -24,10 +24,10 @@ int getpid(void);
 char* sys_sbrk(int,int);
 int pause(int);
 int uptime(void);
-int ctime(void);
+uint64 ctime(void);
 int timtog(void);
-int getkt(void);
-int getut(void);
+uint64 getkt(void);
+uint64 getut(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -27,6 +27,7 @@ int uptime(void);
 int ctime(void);
 int timtog(void);
 int getkt(void);
+int getut(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -27,8 +27,6 @@ int pause(int);
 int uptime(void);
 uint64 ctime(void);
 int timtog(void);
-uint64 getkt(uint64 target_pid);
-uint64 getut(uint64 target_pid);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -44,6 +44,4 @@ entry("pause");
 entry("uptime");
 entry("ctime");
 entry("timtog");
-entry("getkt");
-entry("getut");
 entry("wait2");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -45,3 +45,4 @@ entry("uptime");
 entry("ctime");
 entry("timtog");
 entry("getkt");
+entry("getut");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -46,3 +46,4 @@ entry("ctime");
 entry("timtog");
 entry("getkt");
 entry("getut");
+entry("wait2");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -43,3 +43,5 @@ entry("sbrk");
 entry("pause");
 entry("uptime");
 entry("ctime");
+entry("timtog");
+entry("getkt");

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -42,3 +42,4 @@ entry("getpid");
 entry("sbrk");
 entry("pause");
 entry("uptime");
+entry("ctime");


### PR DESCRIPTION
The original time program aims to time other programs. It gives out 3 seperate times, real time (real), user space time (user), and kernel space time (sys)

Usage:
time [program here] [other arguments]

Example:
time ls
time pause (another utility I added to time a 5+ second program)
time mkdir myfolder

Flag
-p :  Prints out the time in POSIX format

Default:
real    0m0.000s
user   0m0.000s
sys     0m0.000s

POSIX (-p):
real   0.00
user  0.00
sys    0.00

Have fun code reviewing this. I'm sure there's a lot of things I can do better in terms of making thing look better and redundancy.