### PR TITLE
Implemented getcwd_user and pwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $K/%.o: $K/%.S
 tags: $(OBJS)
 	etags kernel/*.S kernel/*.c
 
-ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o
+ULIB = $U/ulib.o $U/usys.o $U/printf.o $U/umalloc.o $U/getcwd_user.o
 
 _%: %.o $(ULIB) $U/user.ld
 	$(LD) $(LDFLAGS) -T $U/user.ld -o $@ $< $(ULIB)

--- a/docs/pwd.md
+++ b/docs/pwd.md
@@ -1,0 +1,77 @@
+# pwd - For FogOSv2
+
+## Overview
+
+The print working directory (pwd) command retrieves the user's current working directory and prints it out for the user to see. 
+It is useful and allows the user to see where they are in their file locations and directories.
+
+As the user uses cd to travel into directories, the shell will automatically update the prompt to showcase your location. On startup 
+our current working directory would be root (/) so you will see /$, before typing into the operating system.
+
+## Usage
+
+- pwd can be executed at anytime by typing 'pwd' into the prompt. Here are the steps to ensure the OS will compile and boot as normal
+
+- When preparing the OS follow these steps
+
+-- make clean
+-- make
+-- make qemu
+
+*Once Booted*
+
+-- /$ pwd
+-- / --> output
+
+### Examples
+
+*On Startup*
+/$ pwd
+/
+
+/$ mkdir temp
+/$ cd temp
+/temp$ pwd
+/temp$
+
+/$ mkdir temp
+/$ cd temp
+/temp$ /mkdir temp2
+/temp$ cd ../temp/temp2
+/temp/temp2$ pwd
+/temp/temp2
+
+## Testing
+
+On startup the shell will initialize 6 total directories. There will be 2 main parent directories titled 'test1' and 'test2' respectively.
+Inside 'test1' we have a child directory called 'show'. Inside of 'show' we have a child directory of 'done'
+Inside 'test2' we have 2 children directories named 'show1' and 'show2'
+
+The user must manually cd into these directories and then do pwd on their own.
+
+Expected outcomes will look like
+
+/test1/show/done --> when the user cd's test1, show, and done, then executes pwd
+/test1/show --> when the user cd's test1 and show, then executes pwd
+/test1 --> when the user cd's into test1 and executes pwd
+
+/test2/show1 --> when the user cd's test2 and show1, then executes pwd
+/test2/show2 --> when the user cd's test2 and show2, then executes pwd
+/test2 --> when the user cd's into test2 and executes pwd
+
+/ --> if the executes pwd on bootup
+
+When the user executes cd, the current working directory will update at the same time so special cases such as including will still show the correct
+current working directory.
+
+Examples of this would look like:
+
+/$ cd test1/show/done/../../../test1
+/test1$ pwd
+/test1
+
+/$ cd test2
+/test2$ cd show
+/test2/show$ cd ../show/..
+/test2$ pwd
+/test2

--- a/user/getcwd_user.c
+++ b/user/getcwd_user.c
@@ -1,0 +1,94 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+char cwd[MAX_PATH] = "/";
+
+void
+getcwd_user(const char *path)
+{
+  char newpath[MAX_PATH];
+  char components[32][64];
+  int num_components = 0;
+  int i, j, start, len, comp_len;
+  int newpath_len = 0;
+
+// Checks between relative path and absolute path
+  if (path[0] == '/'){ 
+    i = 0; 
+    while (path[i] != '\0' && i < MAX_PATH - 1){ 
+      newpath[i] = path[i]; 
+      i++; 
+    } 
+    newpath[i] = '\0'; 
+    newpath_len = i; 
+  } else{ 
+    i = 0; 
+    while (cwd[i] != '\0' && i < MAX_PATH - 1){ 
+      newpath[i] = cwd[i]; 
+      i++; 
+    } 
+    newpath_len = i; 
+    if (newpath_len > 0 && newpath[newpath_len - 1] != '/' && newpath_len < MAX_PATH - 1){ 
+      newpath[newpath_len] = '/'; 
+      newpath_len++; 
+    }
+
+    j = 0; 
+    while (path[j] != '\0' && newpath_len < MAX_PATH - 1){ 
+      newpath[newpath_len] = path[j]; 
+      newpath_len++; 
+      j++; 
+    } 
+    newpath[newpath_len] = '\0'; 
+  }
+
+// Begin to build components of CWD
+  start = 0;
+  len = newpath_len;
+
+// This section isolates the component of the cwd so /bin/ would be extracted to put 'bin' in our components[][]
+  for (i = 0; i <= len; i++) {
+    if (newpath[i] == '/' || newpath[i] == '\0'){
+      if (i > start) {
+        comp_len = i - start;
+
+        for (j = 0; j < comp_len && j < 63; j++) {
+          components[num_components][j] = newpath[start + j];
+        }
+        components[num_components][j] = '\0';
+
+        if (components[num_components][0] == '.' && components[num_components][1] == '\0'){
+            // Nop
+        } else if (components[num_components][0] == '.' && components[num_components][1] == '.' && components[num_components][2] == '\0'){
+          // '..' is the parent directory so we would get rid of our recent addition
+          if (num_components > 0){
+            num_components--;
+          }
+        } else{
+          num_components++;
+        }
+      }
+      start = i + 1;
+    }
+  }
+
+//Slowly build the cwd providing each individual component, putting another '/' then rebuilding until complete
+  if (num_components == 0){
+    cwd[0] = '/';
+    cwd[1] = '\0';
+  } else{
+    int pos = 0;
+    for (i = 0; i < num_components && pos < MAX_PATH - 1; i++){
+      cwd[pos] = '/';
+      pos++;
+
+      j = 0;
+      while (components[i][j] != '\0' && pos < MAX_PATH - 1){
+        cwd[pos] = components[i][j];
+        pos++;
+        j++;
+      }
+    }
+    cwd[pos] = '\0';
+  }
+}

--- a/user/init.c
+++ b/user/init.c
@@ -11,6 +11,17 @@
 
 char *argv[] = { "sh", 0 };
 
+//Creates test directories for users on loadup
+static void make_test_directories(void) {
+  mkdir("/test1");
+  mkdir("/test1/show");
+  mkdir("/test1/show/done");
+  mkdir("/test2");
+  mkdir("/test2/show1/");
+  mkdir("/test2/show2/");
+}
+
+
 int
 main(void)
 {
@@ -22,6 +33,7 @@ main(void)
   }
   dup(0);  // stdout
   dup(0);  // stderr
+  make_test_directories(); // makes test directories for users to explore through premade directories
 
   for(;;){
     printf("init: starting sh\n");

--- a/user/sh.c
+++ b/user/sh.c
@@ -134,7 +134,7 @@ runcmd(struct cmd *cmd)
 int
 getcmd(char *buf, int nbuf)
 {
-  write(2, "$ ", 2);
+  fprintf(2, "%s$ ", cwd);
   memset(buf, 0, nbuf);
   gets(buf, nbuf);
   if(buf[0] == 0) // EOF
@@ -166,8 +166,15 @@ main(void)
     if(cmd[0] == 'c' && cmd[1] == 'd' && cmd[2] == ' '){
       // Chdir must be called by the parent, not the child.
       cmd[strlen(cmd)-1] = 0;  // chop \n
-      if(chdir(cmd+3) < 0)
+      if(chdir(cmd+3) < 0){
         fprintf(2, "cannot cd %s\n", cmd+3);
+      } else {
+        // Updates the cwd
+        getcwd_user(cmd+3);
+      }
+    } else if (cmd[0] == 'p' && cmd[1] == 'w' && cmd[2] == 'd' && (cmd[3] == '\n' || cmd[3] == '\0')){
+        // Prints Working Directory
+        printf("%s\n", cwd);
     } else {
       if(fork1() == 0)
         runcmd(parsecmd(cmd));

--- a/user/user.h
+++ b/user/user.h
@@ -1,4 +1,6 @@
 #define SBRK_ERROR ((char *)-1)
+#define MAX_PATH 512
+extern char cwd[MAX_PATH];
 
 struct stat;
 
@@ -39,6 +41,7 @@ int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
 char* sbrk(int);
 char* sbrklazy(int);
+void getcwd_user(const char *path);
 
 // printf.c
 void fprintf(int, const char*, ...) __attribute__ ((format (printf, 2, 3)));


### PR DESCRIPTION
This is an implementation of the pwd (print working directory) command line user utility. To print our working directory, we need to first get the current working directory. This code below gets the current working directory (cwd) then allows the shell to automatically update with the cwd when we change directories throughout our system. Then pwd will execute as a normal command and print our directory in a new line.