### PR TITLE
Implemeted mv and rmdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,10 @@ UPROGS=\
 	$U/_ls\
 	$U/_mkdir\
     $U/_mv\
+    $U/_mvtest\
 	$U/_rm\
     $U/_rmdir\
+    $U/_rmdirtest\
 	$U/_sh\
 	$U/_stressfs\
 	$U/_usertests\

--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ UPROGS=\
 	$U/_ln\
 	$U/_ls\
 	$U/_mkdir\
-    $U/_mv\
-    $U/_mvtest\
+	$U/_mv\
+	$U/_mvtest\
 	$U/_rm\
-    $U/_rmdir\
-    $U/_rmdirtest\
+	$U/_rmdir\
+	$U/_rmdirtest\
 	$U/_sh\
 	$U/_stressfs\
 	$U/_usertests\

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,9 @@ UPROGS=\
 	$U/_ln\
 	$U/_ls\
 	$U/_mkdir\
+    $U/_mv\
 	$U/_rm\
+    $U/_rmdir\
 	$U/_sh\
 	$U/_stressfs\
 	$U/_usertests\

--- a/docs/mv_README.md
+++ b/docs/mv_README.md
@@ -84,17 +84,30 @@ $ mv dir1/x.txt dir2
 $ ls dir2
 x.txt
 
-# Overwrite a file without asking
+# Move into directory with a trailing slash
+$ mkdir ds
+$ echo "hi" > file1.txt
+$ mv file1.txt ds/
+$ ls ds
+file1.txt
+
+# Overwrite a file without asking (-f)
 $ echo old > a.txt
 $ echo new > b.txt
 $ mv -f a.txt b.txt
 # 'b.txt' now contains "old"
 
-# Interactive mode
+# Interactive mode (-i)
 $ echo "A" > one.txt
 $ echo "B" > two.txt
 $ mv -i one.txt two.txt
 mv: overwrite 'two.txt'? (y/Y to confirm)
+# 'two.txt' now contains "A"
+
+# Same file detection
+$ echo "same" > s.txt
+$ mv s.txt ./s.txt
+mv: 's.txt' and './s.txt' are the same file
 ```
 
 ---

--- a/docs/mv_README.md
+++ b/docs/mv_README.md
@@ -13,6 +13,31 @@ This behavior matches typical `mv`.
 
 ---
 
+## Build Instructions
+To build:
+```sh
+$ make clean
+$ make qemu
+```
+or:
+```sh
+$ make clean && make qemu
+```
+This will compile both commands (`mv` and `rmdir`) and their corresponding test programs (`mvtest`, `rmdirtest`).
+You can verify the binaries are included by running:
+```sh
+$ ls
+```
+You should see entries like:
+```
+mv
+mvtest
+rmdir
+rmdirtest
+```
+
+---
+
 ## Usage
 
 ```sh

--- a/docs/mv_README.md
+++ b/docs/mv_README.md
@@ -1,0 +1,110 @@
+# `mv` Command Documentation
+
+## Overview
+
+The `mv` command moves or renames files.
+It can move files between directories, rename files, or overwrite existing ones (depending on flags).
+
+* If the destination exists, behavior depends on flags (`-f`, `-i`).
+* If the destination is a directory, the source file is placed inside that directory.
+* With the `-v` flag, `mv` prints a confirmation message describing each move.
+
+This behavior matches typical `mv`.
+
+---
+
+## Usage
+
+```sh
+mv [-f] [-i] [-v] SRC DST
+```
+
+### Options
+
+* `-f` – force overwrite without prompting.
+* `-i` – interactive mode; ask before overwriting an existing file.
+* `-v` – verbose mode; print what was moved.
+
+---
+
+## Examples
+
+```sh
+# Rename a file
+$ echo "old data" > old.txt
+$ mv old.txt new.txt
+$ cat new.txt
+old data
+
+# Move a file into a directory
+$ mkdir mydir
+$ mv new.txt mydir
+$ ls mydir
+new.txt
+
+# Move a file out again
+$ mv mydir/new.txt .
+$ ls
+mydir  
+new.txt
+
+# Verbose mode (-v)
+$ mv -v new.txt renamed.txt
+'new.txt' -> 'renamed.txt'
+
+# Move between directories
+$ mkdir dir1 dir2
+$ echo hi > dir1/x.txt
+$ mv dir1/x.txt dir2
+$ ls dir2
+x.txt
+
+# Overwrite a file without asking
+$ echo old > a.txt
+$ echo new > b.txt
+$ mv -f a.txt b.txt
+# 'b.txt' now contains "old"
+
+# Interactive mode
+$ echo "A" > one.txt
+$ echo "B" > two.txt
+$ mv -i one.txt two.txt
+mv: overwrite 'two.txt'? (y/Y to confirm)
+```
+
+---
+
+## Test Program
+
+The `mvtest` program automatically verifies correct behavior.
+**Please run it before you try anything manually!**
+
+Run it with:
+
+```sh
+$ mvtest
+```
+
+Expected output:
+
+```
+Test: simple move... OK
+Test: -f overwrite... OK
+Test: -v verbose output... OK
+Test: move into directory... OK
+Test: same file detection... mv: 's.txt' and './s.txt' are the same file
+OK
+Test: move into dir with trailing slash... OK
+Test: move file between directories... OK
+Manual test: run `mv -i src dst` and try typing y/n yourself.
+```
+
+---
+
+## Notes
+* mv can move files both into and out of directories.
+* Moving a file to itself (like `mv file ./file`) prints an error and does nothing.
+* Moving files into existing directories works with or without a trailing slash.
+* Interactive (`-i`) mode requires manual input.
+* Force (`-f`) mode skips confirmation.
+* Verbose (`-v`) mode prints every rename in `'SRC' -> 'DST'` format.

--- a/docs/rmdir_README.md
+++ b/docs/rmdir_README.md
@@ -1,0 +1,82 @@
+`rmdir` Command Documentation
+
+## Overview
+
+The `rmdir` program removes **empty directories**.
+
+* If the directory is **not empty**, it prints an error and does nothing.
+* If the path is not a directory, it also prints an error.
+* With the `-v` flag, `rmdir` prints a confirmation message when a directory is successfully removed.
+
+This behavior matches typical `rmdir`.
+
+---
+
+## Usage
+
+```sh
+rmdir [-v] DIR [DIR ...]
+```
+
+* `DIR [DIR ...]` – one or more directories to remove.
+* `-v` – verbose mode, prints a message for each directory removed.
+
+---
+
+## Examples
+
+```sh
+# Remove an empty directory
+$ mkdir emptydir
+$ rmdir emptydir
+# (no output, directory gone)
+
+# Try removing a non-empty directory
+$ mkdir full
+$ echo hello > full/file.txt
+$ rmdir full
+rmdir: full: directory not empty
+
+# Verbose mode
+$ mkdir vdir
+$ rmdir -v vdir
+rmdir: removed directory 'vdir'
+
+# Multiple arguments
+$ mkdir d1 d2
+$ rmdir d1 d2
+# Both removed if empty
+```
+
+---
+
+## Test Program
+
+We provide `rmdirtest` to automatically check correctness.
+
+Run it with:
+
+```sh
+$ rmdirtest
+```
+
+Expected output:
+
+```
+Test: remove one empty directory... OK
+Test: remove multiple directories... OK
+Test: refuse non-empty directory... rmdir: full: directory not empty
+OK
+Test: refuse non-directory... rmdir: afile.txt: not a directory
+OK
+Test: -v prints confirmation... OK
+Manual: try `rmdir` with multiple args yourself in the shell.
+```
+
+---
+
+## Notes
+
+* `rmdir` in this implementation only removes empty directories..
+* It can handle multiple directory arguments in a single call.
+* The `-v` flag is optional and useful for scripts that want confirmation.

--- a/docs/rmdir_README.md
+++ b/docs/rmdir_README.md
@@ -12,6 +12,31 @@ This behavior matches typical `rmdir`.
 
 ---
 
+## Build Instructions
+To build:
+```sh
+$ make clean
+$ make qemu
+```
+or:
+```sh
+$ make clean && make qemu
+```
+This will compile both commands (`mv` and `rmdir`) and their corresponding test programs (`mvtest`, `rmdirtest`).
+You can verify the binaries are included by running:
+```sh
+$ ls
+```
+You should see entries like:
+```
+mv
+mvtest
+rmdir
+rmdirtest
+```
+
+---
+
 ## Usage
 
 ```sh

--- a/docs/rmdir_README.md
+++ b/docs/rmdir_README.md
@@ -1,4 +1,4 @@
-`rmdir` Command Documentation
+# `rmdir` Command Documentation
 
 ## Overview
 
@@ -53,7 +53,7 @@ $ rmdir d1 d2
 ## Test Program
 
 We provide `rmdirtest` to automatically check correctness.
-
+**Please run it before you try anything manually!**
 Run it with:
 
 ```sh

--- a/docs/rmdir_README.md
+++ b/docs/rmdir_README.md
@@ -54,7 +54,7 @@ rmdir [-v] DIR [DIR ...]
 # Remove an empty directory
 $ mkdir emptydir
 $ rmdir emptydir
-# (no output, directory gone)
+# (no output, directory removed)
 
 # Try removing a non-empty directory
 $ mkdir full
@@ -62,15 +62,21 @@ $ echo hello > full/file.txt
 $ rmdir full
 rmdir: full: directory not empty
 
-# Verbose mode
+# Verbose mode (-v)
 $ mkdir vdir
 $ rmdir -v vdir
 rmdir: removed directory 'vdir'
 
-# Multiple arguments
+# Multiple empty directories
 $ mkdir d1 d2
 $ rmdir d1 d2
 # Both removed if empty
+
+# Try removing a non-directory
+$ echo hello > afile.txt
+$ rmdir afile.txt
+rmdir: afile.txt: not a directory
+
 ```
 
 ---

--- a/docs/rmdir_README.md
+++ b/docs/rmdir_README.md
@@ -70,7 +70,7 @@ OK
 Test: refuse non-directory... rmdir: afile.txt: not a directory
 OK
 Test: -v prints confirmation... OK
-Manual: try `rmdir` with multiple args yourself in the shell.
+Manual:  try `rmdir` with multiple args or flag -v yourself in the shell.
 ```
 
 ---

--- a/user/mv.c
+++ b/user/mv.c
@@ -1,0 +1,178 @@
+// user/mv.c
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define MV_MAXPATH 256
+
+// Get basename of path, strip dir and trailing slashes
+static const char *
+base_of(const char *path)
+{
+  // Start from the end of the string
+  const char *end = path + strlen(path);
+  // Drop any trailing slashes
+  while (end > path && end[-1] == '/') {
+    end--;
+  }
+  // Move backwards until the last slash or the beginning
+  while (end > path && end[-1] != '/') {
+    end--;
+  }
+  // Now points to the basename
+  return end;
+}
+
+// Check if a path is a directory
+static int
+is_dir(const char *path)
+{
+  struct stat st;
+
+  if (stat(path, &st) < 0) {
+    return 0;
+  }
+  
+  return st.type == T_DIR;
+}
+
+static void 
+usage(void) 
+{
+  printf("usage: mv [-f] [-i] [-v] SRC DST\n");
+}
+
+// Join directory path + filename into one full path string
+static int 
+path_join(char *out, int out_size, const char *dir, const char *name) 
+{
+  int dir_len = strlen(dir);
+  int name_len = strlen(name);
+  int need_slash = (dir_len == 0 || dir[dir_len-1] != '/');
+  int total_len = dir_len; 
+  if (need_slash) {
+    total_len += 1;
+  }
+  total_len += name_len;
+  total_len += 1;
+  if (total_len > out_size) {
+    return -1;
+  }
+  memmove(out, dir, dir_len);
+  int pos = dir_len;
+  if (need_slash) {
+    out[pos++] = '/';
+  }
+  memmove(out + pos, name, name_len);
+  pos += name_len;
+  out[pos] = '\0';
+  return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+  int argi = 1; 
+  int force = 0;
+  int interactive = 0;
+  int verbose = 0;
+  int was_interactive_ok = 0;
+  
+  if (argc < 3) {
+    usage();
+    exit(1);
+  }
+  // Parse flags
+  while (argi < argc && argv[argi][0] == '-') {
+    if (strcmp(argv[argi], "-f") == 0) {
+        force = 1;
+    } else if (strcmp(argv[argi], "-i") == 0) {
+        interactive = 1;
+    } else if (strcmp(argv[argi], "-v") == 0) {
+        verbose = 1;
+    } else {
+        usage();
+        exit(1);
+    }
+    argi++;
+  }
+  if (argc - argi < 2) { 
+    usage(); 
+    exit(1); 
+  }
+
+  char *src = argv[argi++];
+  char *dst = argv[argi++];
+
+  if (is_dir(src)) {
+    printf("mv: %s: is a directory (unsupported)\n", src);
+    exit(1);
+  }
+
+  char finaldst[MV_MAXPATH];
+  if (is_dir(dst)) {
+    const char *base = base_of(src);
+    if (path_join(finaldst, sizeof(finaldst), dst, base) < 0) {
+      printf("mv: destination path too long\n");
+      exit(1);
+    }
+  } else {
+    if ((int)strlen(dst) + 1 > (int)sizeof(finaldst)) {
+      printf("mv: destination path too long\n");
+      exit(1);
+    }
+    strcpy(finaldst, dst);
+  }
+
+  struct stat sst, dstst;
+  if (stat(src, &sst) == 0 && stat(finaldst, &dstst) == 0) {
+    if (sst.dev == dstst.dev && sst.ino == dstst.ino) {
+        printf("mv: '%s' and '%s' are the same file\n", src, finaldst);
+        exit(1);
+    }
+  }
+  
+  if (stat(finaldst, &dstst) == 0 && dstst.type != T_DIR) {
+    if (interactive && !force) {
+      printf("mv: overwrite '%s'? (y/Y to confirm)\n", finaldst);
+      char ch;
+      if (read(0, &ch, 1) != 1 || (ch != 'y' && ch != 'Y')) {
+        printf("not overwritten\n");
+        exit(0);
+      }
+      char dummy;
+      while (read(0, &dummy, 1) == 1 && dummy != '\n');
+      was_interactive_ok = 1;
+    } else if (!force) {
+      printf("mv: %s exists (use -f to overwrite)\n", finaldst);
+      exit(1);
+    }
+    
+    if (unlink(finaldst) < 0) {
+      printf("mv: cannot remove %s\n", finaldst);
+      exit(1);
+    }
+  }
+
+  if (link(src, finaldst) < 0) {
+    printf("mv: cannot link %s -> %s\n", src, finaldst);
+    exit(1);
+  }
+  
+  if (unlink(src) < 0) {
+    printf("mv: warning: linked but failed to remove %s\n", src);
+    exit(1);
+  }
+
+  if (was_interactive_ok) {
+    printf("mv: '%s' overwritten with '%s'\n", finaldst, src);
+  }
+  
+  if (verbose) {
+    printf("'%s' -> '%s'\n", src, finaldst);
+  }
+  
+  exit(0);
+}

--- a/user/mvtest.c
+++ b/user/mvtest.c
@@ -1,0 +1,231 @@
+// user/mvtest.c
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "kernel/fs.h"
+#include "user/user.h"
+
+static int 
+run_mv(char *argv[]) 
+{
+  int pid = fork();
+  if (pid == 0) {
+    exec("mv", argv);
+    printf("exec mv failed\n");
+    exit(1);
+  }
+  int status;
+  wait(&status);
+  return status;
+}
+
+static int
+contains(const char *text, const char *substring)
+{
+  int text_len = strlen(text);
+  int sub_len  = strlen(substring);
+
+  if (sub_len == 0) {
+    return 1;
+  }
+
+  if (text_len < sub_len) {
+    return 0;
+  }
+
+  for (int i = 0; i <= text_len - sub_len; i++) {
+    int j = 0;
+    while (j < sub_len && text[i + j] == substring[j]) {
+      j++;
+    }
+    if (j == sub_len) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static void 
+create_file(const char *name, const char *content) 
+{
+  unlink(name);
+  int fd = open(name, O_CREATE|O_WRONLY);
+  if (fd < 0) {
+    printf("create %s failed\n", name);
+    exit(1);
+  }
+  write(fd, content, strlen(content));
+  close(fd);
+}
+
+static int 
+file_exists(const char *name) 
+{
+  struct stat st;
+  return stat(name, &st) == 0;
+}
+
+static void 
+test_simple_move() 
+{
+  printf("Test: simple move... ");
+  create_file("a.txt", "hello");
+
+  char *argv[] = {"mv", "a.txt", "b.txt", 0};
+  run_mv(argv);
+
+  if (!file_exists("a.txt") && file_exists("b.txt")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+  unlink("b.txt");
+}
+
+static void 
+test_force_overwrite() 
+{
+  printf("Test: -f overwrite... ");
+  create_file("c.txt", "old");
+  create_file("d.txt", "new");
+
+  char *argv[] = {"mv", "-f", "c.txt", "d.txt", 0};
+  run_mv(argv);
+
+  int fd = open("d.txt", O_RDONLY);
+  if (fd < 0) {
+    printf("FAIL (cannot open d.txt)\n");
+    unlink("d.txt");
+    return;
+  }
+  char buf[32];
+  int n = read(fd, buf, sizeof(buf)-1);
+  close(fd);
+  if (n < 0) {
+    n = 0;
+  }
+  buf[n] = 0;
+
+  if (contains(buf,"old")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+  unlink("d.txt");
+}
+
+static void 
+test_verbose() 
+{
+  printf("Test: -v verbose output... ");
+  create_file("v1.txt", "vvv");
+
+  int out = open("out.txt", O_CREATE|O_WRONLY|O_TRUNC);
+  if (out < 0) {
+    printf("FAIL (cannot open out.txt)\n");
+    return;
+  }
+  int saved = dup(1);
+
+  close(1);
+  dup(out);
+
+  char *argv[] = {"mv", "-v", "v1.txt", "v2.txt", 0};
+  run_mv(argv);
+
+  close(out);
+  close(1);
+  dup(saved);
+  close(saved);
+  int fd = open("out.txt", O_RDONLY);
+  if (fd < 0) {
+    printf("FAIL (cannot read out.txt)\n");
+    unlink("out.txt");
+    unlink("v2.txt");
+    return;
+  }
+  char buf[128];
+  int n = read(fd, buf, sizeof(buf)-1);
+  close(fd);
+  if (n < 0) {
+    n = 0;
+  }
+  buf[n] = 0;
+
+  if (contains(buf,"v1.txt") && contains(buf,"v2.txt")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+  unlink("out.txt");
+  unlink("v2.txt");
+}
+
+static void 
+test_move_into_dir() 
+{
+  printf("Test: move into directory... ");
+  mkdir("d");
+
+  create_file("x", "data");
+  char *argv[] = {"mv", "x", "d", 0};
+  run_mv(argv);
+
+  if (!file_exists("x") && file_exists("d/x")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+
+  unlink("d/x");
+  unlink("d");
+}
+
+static void 
+test_same_file() 
+{
+  printf("Test: same file detection... ");
+  create_file("s.txt", "same");
+
+  char *argv[] = {"mv", "s.txt", "./s.txt", 0};
+  int rc = run_mv(argv);
+
+  if (rc != 0 && file_exists("s.txt")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+  unlink("s.txt");
+}
+
+static void 
+test_move_into_dir_with_slash() 
+{
+  printf("Test: move into dir with trailing slash... ");
+  mkdir("ds");
+  create_file("x2", "data");
+  char *argv[] = {"mv", "x2", "ds/", 0};
+  run_mv(argv);
+  if (!file_exists("x2") && file_exists("ds/x2")) {
+    printf("OK\n");
+  } else {
+      printf("FAIL\n");
+  }
+  
+  unlink("ds/x2");
+  unlink("ds");
+}
+
+int
+main(int argc, char *argv[])
+{
+  test_simple_move();
+  test_force_overwrite();
+  test_verbose();
+  test_move_into_dir();
+  test_same_file();
+  test_move_into_dir_with_slash();
+  printf("Manual test: run `mv -i src dst` and try typing y/n yourself.\n");
+  exit(0);
+}

--- a/user/mvtest.c
+++ b/user/mvtest.c
@@ -217,6 +217,28 @@ test_move_into_dir_with_slash()
   unlink("ds");
 }
 
+static void 
+test_move_between_dirs() 
+{
+  printf("Test: move file between directories... ");
+  mkdir("dir1");
+  mkdir("dir2");
+  create_file("dir1/x3", "content");
+
+  char *argv[] = {"mv", "dir1/x3", "dir2", 0};
+  run_mv(argv);
+
+  if (!file_exists("dir1/x3") && file_exists("dir2/x3")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+
+  unlink("dir2/x3");
+  unlink("dir1");
+  unlink("dir2");
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -226,6 +248,7 @@ main(int argc, char *argv[])
   test_move_into_dir();
   test_same_file();
   test_move_into_dir_with_slash();
+  test_move_between_dirs();
   printf("Manual test: run `mv -i src dst` and try typing y/n yourself.\n");
   exit(0);
 }

--- a/user/rmdir.c
+++ b/user/rmdir.c
@@ -1,0 +1,108 @@
+// user/rmdir.c
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+static void
+usage(void)
+{
+  printf("usage: rmdir [-v] DIR [DIR ...]\n");
+}
+
+// Check if path is a directory
+static int
+is_dir(const char *path)
+{
+  struct stat st;
+  if (stat(path, &st) < 0) {
+    return 0;
+  }
+  return st.type == T_DIR;
+}
+
+// Check if entry is "." or ".."
+static int
+is_dot_or_dotdot(const char *s)
+{
+  return (strcmp(s, ".") == 0) || (strcmp(s, "..") == 0);
+}
+
+// Remove one directory
+static int
+rmdir_one(const char *path, int verbose)
+{
+  if (!is_dir(path)) {
+    printf("rmdir: %s: not a directory\n", path);
+    return -1;
+  }
+
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    printf("rmdir: cannot open %s\n", path);
+    return -1;
+  }
+
+  struct dirent entry;
+  int empty = 1;
+  while (read(fd, &entry, sizeof(entry)) == sizeof(entry)) {
+    if (entry.inum == 0) {
+      continue;
+    }
+
+    char name[DIRSIZ+1];
+    memmove(name, entry.name, DIRSIZ);
+    name[DIRSIZ] = 0;
+
+    if (is_dot_or_dotdot(name)) {
+      continue;
+    }
+    empty = 0; 
+    break;
+  }
+  close(fd);
+
+  if (!empty) {
+    printf("rmdir: %s: directory not empty\n", path);
+    return -1;
+  }
+
+  if (unlink(path) < 0) {
+    printf("rmdir: failed to remove %s\n", path);
+    return -1;
+  }
+
+  if (verbose) {
+    printf("rmdir: removed directory '%s'\n", path);
+  }
+  
+  return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+  if (argc < 2) { 
+    usage(); 
+    exit(1); 
+  }
+  int verbose = 0;
+  int argi = 1;
+  if (strcmp(argv[argi], "-v") == 0) {
+    verbose = 1;
+    argi++;
+    if (argi >= argc) {
+        usage();
+        exit(1);
+    }
+  }
+  
+  int rc = 0;
+  for (int i = argi; i < argc; i++) {
+    if (rmdir_one(argv[i], verbose) < 0)
+      rc = 1;
+  }
+
+  exit(rc);
+}

--- a/user/rmdirtest.c
+++ b/user/rmdirtest.c
@@ -1,0 +1,208 @@
+// user/rmdirtest.c
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+static int
+contains(const char *text, const char *substring)
+{
+  int text_len = strlen(text);
+  int sub_len  = strlen(substring);
+
+  if (sub_len == 0) {
+    return 1;
+  }
+
+  if (text_len < sub_len) {
+    return 0;
+  }
+
+  for (int i = 0; i <= text_len - sub_len; i++) {
+    int j = 0;
+    while (j < sub_len && text[i + j] == substring[j]) {
+      j++;
+    }
+    if (j == sub_len) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static int
+run_rmdir(char *argv[])
+{
+  int pid = fork();
+  if (pid == 0) {
+    exec("rmdir", argv);
+    printf("exec rmdir failed\n");
+    exit(1);
+  }
+  int status;
+  wait(&status);
+  return status;
+}
+
+// Create a directory
+static void 
+make_dir(const char *name) 
+{
+  mkdir(name);
+}
+
+// Create a file inside a directory
+static void 
+make_file(const char *path, const char *content) 
+{
+  int fd = open(path, O_CREATE|O_WRONLY);
+  if (fd < 0) {
+    printf("create %s failed\n", path);
+    exit(1);
+  }
+  if (content) {
+    write(fd, content, strlen(content));
+  }
+  close(fd);
+}
+
+// Check if path exists
+static int 
+exists(const char *path) 
+{
+  struct stat st;
+  return stat(path, &st) == 0;
+}
+
+static void 
+test_remove_empty() 
+{
+  printf("Test: remove one empty directory... ");
+  unlink("dir1");
+  make_dir("dir1");
+
+  char *argv[] = {"rmdir", "dir1", 0};
+  run_rmdir(argv);
+
+  if (!exists("dir1")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+}
+
+static void 
+test_remove_multiple() 
+{
+  printf("Test: remove multiple directories... ");
+  unlink("d1"); 
+  unlink("d2");
+  make_dir("d1");
+  make_dir("d2");
+
+  char *argv[] = {"rmdir", "d1", "d2", 0};
+  run_rmdir(argv);
+
+  if (!exists("d1") && !exists("d2")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+}
+
+static void 
+test_non_empty() 
+{
+  printf("Test: refuse non-empty directory... ");
+  unlink("full/file.txt");
+  unlink("full");
+  make_dir("full");
+  make_file("full/file.txt", "data");
+
+  char *argv[] = {"rmdir", "full", 0};
+  int rc = run_rmdir(argv);
+
+  if (rc != 0 && exists("full")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+
+  unlink("full/file.txt");
+  unlink("full");
+}
+
+static void 
+test_not_dir() 
+{
+  printf("Test: refuse non-directory... ");
+  unlink("afile.txt");
+  make_file("afile.txt", "hello");
+
+  char *argv[] = {"rmdir", "afile.txt", 0};
+  int rc = run_rmdir(argv);
+
+  if (rc != 0 && exists("afile.txt")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+
+  unlink("afile.txt");
+}
+
+static void
+test_verbose()
+{
+  printf("Test: -v prints confirmation... ");
+  unlink("vdir");
+  mkdir("vdir");
+  int out = open("out.txt", O_CREATE | O_WRONLY | O_TRUNC);
+  if (out < 0) {
+    printf("FAIL (cannot open out.txt)\n");
+    return;
+  }
+  int saved = dup(1);
+  close(1);
+  dup(out); 
+  char *argv[] = {"rmdir", "-v", "vdir", 0};
+  int rc = run_rmdir(argv);
+  close(out);
+  close(1);
+  dup(saved);
+  close(saved);
+  int fd = open("out.txt", O_RDONLY);
+  
+  if (fd < 0) {
+    printf("FAIL (cannot read out.txt)\n");
+    return;
+  }
+  
+  char buf[256];
+  int n = read(fd, buf, sizeof(buf) - 1);
+  close(fd);
+  if (n < 0) {
+    n = 0;
+  }
+  buf[n] = 0;
+  if (rc == 0 && contains(buf, "removed directory") && contains(buf, "vdir")) {
+    printf("OK\n");
+  } else {
+    printf("FAIL\n");
+  }
+  unlink("out.txt");
+  unlink("vdir");
+}
+
+int
+main(int argc, char *argv[])
+{
+  test_remove_empty();
+  test_remove_multiple();
+  test_non_empty();
+  test_not_dir();
+  test_verbose();
+  printf("Manual: try `rmdir` with multiple args or flag -v yourself in the shell.\n");
+  exit(0);
+}


### PR DESCRIPTION
**Summary**
We implemented: mv (move/rename files) and rmdir (remove empty directories), along with their respective automated test programs mvtest and rmdirtest.

---

**Features Implemented**
**mv**
- Moves or renames files.
- Supports moving files between directories (with or without trailing slashes).
- Prevents moving a file to itself.
- Handles overwriting and confirmation prompts via:
  - -f → force overwrite
  - -i → interactive confirmation before overwrite
  - -v → verbose mode (prints 'SRC' -> 'DST')


**rmdir**
- Removes empty directories.
- Refuses to remove non-empty directories or non-directory paths.
- Supports:
  - Removing multiple directories at once
  - -v flag to print a confirmation message when directories are removed

---

## Build Instructions
To build:
$ make clean
$ make qemu
or:
$ make clean && make qemu
This will compile both commands (`mv` and `rmdir`) and their corresponding test programs (`mvtest`, `rmdirtest`).
You can verify the binaries are included by running:
$ ls
You should see entries like:
mv
mvtest
rmdir
rmdirtest

---

**Automated Tests**
**mvtest**
Validates:
- Simple file moves and renames
- Force overwrite (-f)
- Verbose mode output (-v)
- Moving files into and between directories
- Handling of trailing slashes in directory paths
- Detection of same-file moves

**rmdirtest**
Validates:
- Removing single and multiple empty directories
- Refusing to remove non-empty directories
- Refusing to remove files that are not directories
- Printing correct output in verbose mode (-v)

---

**Documentation**
Added Markdown documentation:
1. docs/mv_README.md – build instruction, usage, examples, and explanation of flags and behaviors
2. docs/rmdir_README.md – build instruction, usage, examples, and test output
Each document includes both manual examples and expected test outputs.

---

**How to Test**
After building the user programs, run:
$ mvtest

**Expected results:**
Test: simple move... OK
Test: -f overwrite... OK
Test: -v verbose output... OK
Test: move into directory... OK
Test: same file detection... mv: 's.txt' and './s.txt' are the same file
OK
Test: move into dir with trailing slash... OK
Test: move file between directories... OK
Manual test: run `mv -i src dst` and try typing y/n yourself.

$ rmdirtest
**Expected results:**
Test: remove one empty directory... OK
Test: remove multiple directories... OK
Test: refuse non-empty directory... rmdir: full: directory not empty
OK
Test: refuse non-directory... rmdir: afile.txt: not a directory
OK
Test: -v prints confirmation... OK
Manual: try `rmdir` with multiple args or flag -v yourself in the shell.



